### PR TITLE
Promote to prod environment

### DIFF
--- a/components/go-vbplyxur/overlays/prod/deployment-patch.yaml
+++ b/components/go-vbplyxur/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-appstudio/rhtap-task-runner:latest
+      - image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-vbplyxur:github-5506360b83ce893a218aea259f015293d7666ed8
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: artifactory-docker-artifactory-jcr2.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/go-vbplyxur:github-5506360b83ce893a218aea259f015293d7666ed8